### PR TITLE
Increase selection and comment contrast

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -1,7 +1,7 @@
 // General
 @syntax-text-color: #F1EFF7;
 @syntax-cursor-color: #94F2E7;
-@syntax-selection-color: #383A62;
+@syntax-selection-color: #4F528A;
 @syntax-background-color: #292A44;
 @syntax-bracket-matcher: #6DFEDF;
 
@@ -27,7 +27,7 @@
 @syntax-color-removed: #CC6666;
 
 // Syntax
-@syntax-type-comment: #57578B;
+@syntax-type-comment: #6D6DB5;
 @syntax-type-string: #6DFEDF;
 @syntax-type-numeric: #FFDB7D;
 @syntax-type-lang: #AE81FF;


### PR DESCRIPTION
Found these easier to read/notice this way:

![changes](https://d17oy1vhnax1f7.cloudfront.net/items/0721401I39400q2E2h0D/Screen%20Shot%202016-12-23%20at%207.35.39%20PM.png)

Thought you might think so too. 🙂

(dope theme btw, reminds me of this fella)
![Gloom](http://bogleech.com/pokemon/sprites/044Gloomsprite3.png)