### PR TITLE
Include syntax--md class when applying Markdown syntax highlighting

### DIFF
--- a/styles/syntax/markdown.less
+++ b/styles/syntax/markdown.less
@@ -1,4 +1,4 @@
-.syntax--markup.syntax--gfm {
+.syntax--markup.syntax--gfm, .syntax--markup.syntax--md {
 
   &.syntax--heading {
     color: @syntax-type-definition;
@@ -10,7 +10,7 @@
 
 }
 
-.syntax--gfm .syntax--link {
+.syntax--gfm .syntax--link, .syntax--md .syntax--link {
 
   &:hover {
     background: fade(@syntax-type-structure, 20%);


### PR DESCRIPTION
Hi @hejrobin - just wanted to bring this change in so my Markdown files would get a bit of Gloom prettiness.

I believe they are getting the `syntax--md` class applied due to me having https://atom.io/packages/language-markdown installed.